### PR TITLE
docs: update README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 *An HTML-first, GSD-focused library for building LiveViews in NodeJS and Deno*
 
-Documentation: [LiveViewJS.com](http://liveviewjs.com)
+Documentation: [LiveViewJS.com](https://www.liveviewjs.com)


### PR DESCRIPTION
When I clicked on the link from the main README, I got a security warning from Firefox:

<img width="1728" alt="Screen Shot 2022-09-23 at 16 00 10" src="https://user-images.githubusercontent.com/630449/192062527-51bf338b-3b42-4e48-b2ef-78b749e25106.png">

It's just warning that the link is HTTP (it does redirect to HTTPS). To avoid that scary page, this PR updates the link to the HTTPS version.