### PR TITLE
Fix Deno package README and docs

### DIFF
--- a/apps/liveviewjs.com/docs/02-quick-starts/deno-run-examples.md
+++ b/apps/liveviewjs.com/docs/02-quick-starts/deno-run-examples.md
@@ -23,10 +23,16 @@ Navigate to the `packages/deno` directory:
 cd packages/deno
 ```
 
+Install dependencies:
+
+```bash
+npm install
+```
+
 Then, start the Deno server with the examples:
 
 ```bash
-deno run --allow-run --allow-read --allow-env  src/example/autorun.ts
+deno run --allow-run --allow-read --allow-write --allow-net --allow-env  src/example/autorun.ts
 ```
 
 Point your browser to [http://localhost:9001](http://localhost:9001)

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -126,6 +126,9 @@ Check out the full LiveViewJS repository:
 `cd` to this package:
 `cd packages/deno`
 
+Install dependencies:
+`npm install`
+
 Then run the following command:
 `deno run --allow-run --allow-read --allow-write --allow-net --allow-env  src/example/autorun.ts`
 


### PR DESCRIPTION
Closes #108

The issue was partially fixed. This PR also adds `npm install` as discussed in the issue and updates the `deno run` command in the docs.